### PR TITLE
Namespace stimulus controller

### DIFF
--- a/lib/phlex_ui/popover.rb
+++ b/lib/phlex_ui/popover.rb
@@ -16,8 +16,8 @@ module PhlexUI
     def default_attrs
       {
         data: {
-          controller: "popover",
-          popover_options_value: @options.to_json
+          controller: "ui-popover",
+          ui_popover_options_value: @options.to_json
         }
       }
     end

--- a/lib/phlex_ui/popover/content.rb
+++ b/lib/phlex_ui/popover/content.rb
@@ -3,7 +3,7 @@
 module PhlexUI
   class Popover::Content < Base
     def template(&block)
-      template_tag(data: {popover_target: "content"}) do
+      template_tag(data: {ui_popover_target: "content"}) do
         div(**attrs, &block)
       end
     end

--- a/lib/phlex_ui/popover/trigger.rb
+++ b/lib/phlex_ui/popover/trigger.rb
@@ -11,7 +11,7 @@ module PhlexUI
     def default_attrs
       {
         data: {
-          popover_target: "trigger"
+          ui_popover_target: "trigger"
         },
         class: "inline-block"
       }


### PR DESCRIPTION
I think it would be good to namespace stimulus controllers to phlex incase someone has a controller with the same name and break a component.