### PR TITLE
Renaming `template` method to `view_template`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     phlex_ui (0.1.7)
-      phlex (~> 1.7)
+      phlex (~> 1.10)
       rouge (~> 4.2.0)
       ruby-next (~> 1.0)
       zeitwerk (~> 2.6)
@@ -11,11 +11,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    cgi (0.4.1)
-    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
-    erb (4.0.3)
-      cgi (>= 0.3.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
@@ -24,10 +20,7 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
-    phlex (1.9.0)
-      concurrent-ruby (~> 1.2)
-      erb (>= 4)
-      zeitwerk (~> 2.6)
+    phlex (1.10.0)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)

--- a/lib/phlex_ui/accordion.rb
+++ b/lib/phlex_ui/accordion.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Accordion < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/accordion/builder.rb
+++ b/lib/phlex_ui/accordion/builder.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Accordion::Builder < Base
-    def template(&block)
+    def view_template(&block)
       render PhlexUI::Accordion.new(**attrs) do
         block.call
       end

--- a/lib/phlex_ui/accordion/content.rb
+++ b/lib/phlex_ui/accordion/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Accordion::Content < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/accordion/default_content.rb
+++ b/lib/phlex_ui/accordion/default_content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Accordion::DefaultContent < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/accordion/default_trigger.rb
+++ b/lib/phlex_ui/accordion/default_trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Accordion::DefaultTrigger < Base
-    def template(&block)
+    def view_template(&block)
       div(class: "flex items-center justify-between w-full") do
         p(&block)
         render ::PhlexUI::Accordion::Icon.new

--- a/lib/phlex_ui/accordion/icon.rb
+++ b/lib/phlex_ui/accordion/icon.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Accordion::Icon < Base
-    def template(&block)
+    def view_template(&block)
       span(**attrs) do
         if block
           block.call

--- a/lib/phlex_ui/accordion/item.rb
+++ b/lib/phlex_ui/accordion/item.rb
@@ -8,7 +8,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/accordion/trigger.rb
+++ b/lib/phlex_ui/accordion/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Accordion::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       button(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert.rb
+++ b/lib/phlex_ui/alert.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs) # must be called after variant is set
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert/description.rb
+++ b/lib/phlex_ui/alert/description.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Alert::Description < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert/title.rb
+++ b/lib/phlex_ui/alert/title.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Alert::Title < Base
-    def template(&block)
+    def view_template(&block)
       h5(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert_dialog.rb
+++ b/lib/phlex_ui/alert_dialog.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&)
+    def view_template(&)
       div(**attrs, &)
     end
 

--- a/lib/phlex_ui/alert_dialog/action.rb
+++ b/lib/phlex_ui/alert_dialog/action.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class AlertDialog::Action < Base
-    def template(&block)
+    def view_template(&block)
       render PhlexUI::Button.new(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert_dialog/cancel.rb
+++ b/lib/phlex_ui/alert_dialog/cancel.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class AlertDialog::Cancel < Base
-    def template(&block)
+    def view_template(&block)
       render PhlexUI::Button.new(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert_dialog/content.rb
+++ b/lib/phlex_ui/alert_dialog/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class AlertDialog::Content < Base
-    def template(&block)
+    def view_template(&block)
       template_tag(**attrs) do
         div(data: {controller: "dismissable"}) do
           background

--- a/lib/phlex_ui/alert_dialog/description.rb
+++ b/lib/phlex_ui/alert_dialog/description.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class AlertDialog::Description < Base
-    def template(&block)
+    def view_template(&block)
       p(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert_dialog/footer.rb
+++ b/lib/phlex_ui/alert_dialog/footer.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class AlertDialog::Footer < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert_dialog/header.rb
+++ b/lib/phlex_ui/alert_dialog/header.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class AlertDialog::Header < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert_dialog/title.rb
+++ b/lib/phlex_ui/alert_dialog/title.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class AlertDialog::Title < Base
-    def template(&block)
+    def view_template(&block)
       h2(**attrs, &block)
     end
 

--- a/lib/phlex_ui/alert_dialog/trigger.rb
+++ b/lib/phlex_ui/alert_dialog/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class AlertDialog::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/aspect_ratio.rb
+++ b/lib/phlex_ui/aspect_ratio.rb
@@ -9,7 +9,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(
         class: "relative w-full",
         style: "padding-bottom: #{padding_bottom}%;"

--- a/lib/phlex_ui/avatar.rb
+++ b/lib/phlex_ui/avatar.rb
@@ -16,7 +16,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       span(**attrs, &block)
     end
 

--- a/lib/phlex_ui/avatar/builder.rb
+++ b/lib/phlex_ui/avatar/builder.rb
@@ -10,7 +10,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template
+    def view_template
       render PhlexUI::Avatar.new(size: @size, **attrs) do
         render_image if @src
         render_initials if @initials

--- a/lib/phlex_ui/avatar/fallback.rb
+++ b/lib/phlex_ui/avatar/fallback.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Avatar::Fallback < Base
-    def template(&block)
+    def view_template(&block)
       span(**attrs, &block)
     end
 

--- a/lib/phlex_ui/avatar/image.rb
+++ b/lib/phlex_ui/avatar/image.rb
@@ -8,7 +8,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template
+    def view_template
       img(**attrs)
     end
 

--- a/lib/phlex_ui/badge.rb
+++ b/lib/phlex_ui/badge.rb
@@ -45,7 +45,7 @@ module PhlexUI
       super(**args)
     end
 
-    def template(&block)
+    def view_template(&block)
       span(**attrs, &block)
     end
 

--- a/lib/phlex_ui/button.rb
+++ b/lib/phlex_ui/button.rb
@@ -9,7 +9,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       button(**attrs, &block)
     end
 

--- a/lib/phlex_ui/calendar.rb
+++ b/lib/phlex_ui/calendar.rb
@@ -9,7 +9,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template
+    def view_template
       div(**attrs) do
         render PhlexUI::Calendar::Header.new do
           render PhlexUI::Calendar::Title.new

--- a/lib/phlex_ui/calendar/body.rb
+++ b/lib/phlex_ui/calendar/body.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Calendar::Body < Base
-    def template
+    def view_template
       table(**attrs)
     end
 

--- a/lib/phlex_ui/calendar/days.rb
+++ b/lib/phlex_ui/calendar/days.rb
@@ -4,7 +4,7 @@ module PhlexUI
   class Calendar::Days < Base
     BASE_CLASS = "inline-flex items-center justify-center rounded-md text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 h-8 w-8 p-0 font-normal aria-selected:opacity-100"
 
-    def template
+    def view_template
       render_selected_date_template
       render_today_date_template
       render_current_month_date_template

--- a/lib/phlex_ui/calendar/header.rb
+++ b/lib/phlex_ui/calendar/header.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Calendar::Header < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/calendar/next.rb
+++ b/lib/phlex_ui/calendar/next.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Calendar::Next < Base
-    def template(&block)
+    def view_template(&block)
       button(**attrs) do
         icon
       end

--- a/lib/phlex_ui/calendar/prev.rb
+++ b/lib/phlex_ui/calendar/prev.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Calendar::Prev < Base
-    def template(&block)
+    def view_template(&block)
       button(**attrs) do
         icon
       end

--- a/lib/phlex_ui/calendar/title.rb
+++ b/lib/phlex_ui/calendar/title.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template
+    def view_template
       div(**attrs) { @default }
     end
 

--- a/lib/phlex_ui/calendar/weekdays.rb
+++ b/lib/phlex_ui/calendar/weekdays.rb
@@ -4,7 +4,7 @@ module PhlexUI
   class Calendar::Weekdays < Base
     DAYS = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday].freeze
 
-    def template
+    def view_template
       template_tag(data: {calendar_target: "weekdaysTemplate"}) do
         thead(**attrs) do
           tr(class: "flex") do

--- a/lib/phlex_ui/card.rb
+++ b/lib/phlex_ui/card.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Card < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/card/content.rb
+++ b/lib/phlex_ui/card/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Card::Content < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/card/description.rb
+++ b/lib/phlex_ui/card/description.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Card::Description < Base
-    def template(&block)
+    def view_template(&block)
       p(**attrs, &block)
     end
 

--- a/lib/phlex_ui/card/footer.rb
+++ b/lib/phlex_ui/card/footer.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Card::Footer < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/card/header.rb
+++ b/lib/phlex_ui/card/header.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Card::Header < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/card/title.rb
+++ b/lib/phlex_ui/card/title.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Card::Title < Base
-    def template(&block)
+    def view_template(&block)
       h3(**attrs, &block)
     end
 

--- a/lib/phlex_ui/chart.rb
+++ b/lib/phlex_ui/chart.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       canvas(**attrs, &block)
     end
 

--- a/lib/phlex_ui/checkbox.rb
+++ b/lib/phlex_ui/checkbox.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Checkbox < Base
-    def template
+    def view_template
       input(**attrs)
     end
 

--- a/lib/phlex_ui/clipboard.rb
+++ b/lib/phlex_ui/clipboard.rb
@@ -8,7 +8,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs) do
         div(&block)
         success_popover

--- a/lib/phlex_ui/clipboard/popover.rb
+++ b/lib/phlex_ui/clipboard/popover.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       template_tag(data: {clipboard_target: clipboard_target}) do
         div(**attrs, &block)
       end

--- a/lib/phlex_ui/clipboard/source.rb
+++ b/lib/phlex_ui/clipboard/source.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Clipboard::Source < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/clipboard/trigger.rb
+++ b/lib/phlex_ui/clipboard/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Clipboard::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/codeblock.rb
+++ b/lib/phlex_ui/codeblock.rb
@@ -21,7 +21,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template
+    def view_template
       style { ROUGE_CSS.html_safe } # For faster load times, move this to the head of your document. (Also move ROUGE_CSS value to head of document)
       if @clipboard
         with_clipboard

--- a/lib/phlex_ui/collapsible.rb
+++ b/lib/phlex_ui/collapsible.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/collapsible/content.rb
+++ b/lib/phlex_ui/collapsible/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Collapsible::Content < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/collapsible/trigger.rb
+++ b/lib/phlex_ui/collapsible/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Collapsible::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/command.rb
+++ b/lib/phlex_ui/command.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Command < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/command/dialog.rb
+++ b/lib/phlex_ui/command/dialog.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Command::Dialog < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/command/dialog_content.rb
+++ b/lib/phlex_ui/command/dialog_content.rb
@@ -16,7 +16,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       template_tag(data: {dialog_target: "content"}) do
         div(data: {controller: "dismissable"}) do
           backdrop

--- a/lib/phlex_ui/command/dialog_trigger.rb
+++ b/lib/phlex_ui/command/dialog_trigger.rb
@@ -12,7 +12,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/command/empty.rb
+++ b/lib/phlex_ui/command/empty.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Command::Empty < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/command/group.rb
+++ b/lib/phlex_ui/command/group.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs) do
         render_header if @title
         render_items(&block)

--- a/lib/phlex_ui/command/input.rb
+++ b/lib/phlex_ui/command/input.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template
+    def view_template
       input_container do
         search_icon
         input(**attrs)

--- a/lib/phlex_ui/command/item.rb
+++ b/lib/phlex_ui/command/item.rb
@@ -9,7 +9,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       a(**attrs, &block)
     end
 

--- a/lib/phlex_ui/command/list.rb
+++ b/lib/phlex_ui/command/list.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Command::List < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/context_menu.rb
+++ b/lib/phlex_ui/context_menu.rb
@@ -8,7 +8,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/context_menu/content.rb
+++ b/lib/phlex_ui/context_menu/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class ContextMenu::Content < Base
-    def template(&block)
+    def view_template(&block)
       template_tag(data: {popover_target: "content"}) do
         div(**attrs, &block)
       end

--- a/lib/phlex_ui/context_menu/item.rb
+++ b/lib/phlex_ui/context_menu/item.rb
@@ -11,7 +11,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       a(**attrs) do
         render_checkmark if @checked
         yield

--- a/lib/phlex_ui/context_menu/label.rb
+++ b/lib/phlex_ui/context_menu/label.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/context_menu/separator.rb
+++ b/lib/phlex_ui/context_menu/separator.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class ContextMenu::Separator < Base
-    def template
+    def view_template
       div(**attrs)
     end
 

--- a/lib/phlex_ui/context_menu/trigger.rb
+++ b/lib/phlex_ui/context_menu/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class ContextMenu::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dialog.rb
+++ b/lib/phlex_ui/dialog.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dialog/content.rb
+++ b/lib/phlex_ui/dialog/content.rb
@@ -16,7 +16,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template
+    def view_template
       template_tag(data: {dialog_target: "content"}) do
         div(data: {controller: "dismissable"}) do
           backdrop

--- a/lib/phlex_ui/dialog/description.rb
+++ b/lib/phlex_ui/dialog/description.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Dialog::Description < Base
-    def template(&block)
+    def view_template(&block)
       p(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dialog/footer.rb
+++ b/lib/phlex_ui/dialog/footer.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Dialog::Footer < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dialog/header.rb
+++ b/lib/phlex_ui/dialog/header.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Dialog::Header < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dialog/middle.rb
+++ b/lib/phlex_ui/dialog/middle.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Dialog::Middle < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dialog/title.rb
+++ b/lib/phlex_ui/dialog/title.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Dialog::Title < Base
-    def template(&block)
+    def view_template(&block)
       h3(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dialog/trigger.rb
+++ b/lib/phlex_ui/dialog/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Dialog::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dropdown_menu.rb
+++ b/lib/phlex_ui/dropdown_menu.rb
@@ -8,7 +8,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dropdown_menu/content.rb
+++ b/lib/phlex_ui/dropdown_menu/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class DropdownMenu::Content < Base
-    def template(&block)
+    def view_template(&block)
       template_tag(data: {popover_target: "content"}) do
         div(**attrs, &block)
       end

--- a/lib/phlex_ui/dropdown_menu/item.rb
+++ b/lib/phlex_ui/dropdown_menu/item.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       a(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dropdown_menu/label.rb
+++ b/lib/phlex_ui/dropdown_menu/label.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class DropdownMenu::Label < Base
-    def template(&block)
+    def view_template(&block)
       h3(**attrs, &block)
     end
 

--- a/lib/phlex_ui/dropdown_menu/separator.rb
+++ b/lib/phlex_ui/dropdown_menu/separator.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class DropdownMenu::Separator < Base
-    def template
+    def view_template
       div(**attrs)
     end
 

--- a/lib/phlex_ui/dropdown_menu/trigger.rb
+++ b/lib/phlex_ui/dropdown_menu/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class DropdownMenu::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/form.rb
+++ b/lib/phlex_ui/form.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Form < Base
-    def template(&block)
+    def view_template(&block)
       form(**attrs, &block)
     end
 

--- a/lib/phlex_ui/form/builder.rb
+++ b/lib/phlex_ui/form/builder.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Form::Builder < Base
-    def template(&block)
+    def view_template(&block)
       render PhlexUI::Form.new(**attrs) do
         render PhlexUI::Form::Spacer.new do
           block.call

--- a/lib/phlex_ui/form/item.rb
+++ b/lib/phlex_ui/form/item.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Form::Item < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/form/spacer.rb
+++ b/lib/phlex_ui/form/spacer.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Form::Spacer < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/hint.rb
+++ b/lib/phlex_ui/hint.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Hint < Base
-    def template(&block)
+    def view_template(&block)
       p(**attrs, &block)
     end
 

--- a/lib/phlex_ui/hover_card.rb
+++ b/lib/phlex_ui/hover_card.rb
@@ -9,7 +9,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/hover_card/content.rb
+++ b/lib/phlex_ui/hover_card/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class HoverCard::Content < Base
-    def template(&block)
+    def view_template(&block)
       template_tag(data: {popover_target: "content"}) do
         div(**attrs, &block)
       end

--- a/lib/phlex_ui/hover_card/trigger.rb
+++ b/lib/phlex_ui/hover_card/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class HoverCard::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/input.rb
+++ b/lib/phlex_ui/input.rb
@@ -8,7 +8,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template
+    def view_template
       input(type: @type, **attrs)
       render PhlexUI::InputError.new { @error } if @error
     end

--- a/lib/phlex_ui/input_error.rb
+++ b/lib/phlex_ui/input_error.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class InputError < Base
-    def template(&block)
+    def view_template(&block)
       p(**attrs, &block)
     end
 

--- a/lib/phlex_ui/label.rb
+++ b/lib/phlex_ui/label.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Label < Base
-    def template(&block)
+    def view_template(&block)
       label(**attrs, &block)
     end
 

--- a/lib/phlex_ui/link.rb
+++ b/lib/phlex_ui/link.rb
@@ -10,7 +10,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       a(href: @href, **attrs, &block)
     end
 

--- a/lib/phlex_ui/pagination.rb
+++ b/lib/phlex_ui/pagination.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Pagination < Base
-    def template(&block)
+    def view_template(&block)
       nav(**attrs, &block)
     end
 

--- a/lib/phlex_ui/pagination/content.rb
+++ b/lib/phlex_ui/pagination/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Pagination::Content < Base
-    def template(&block)
+    def view_template(&block)
       ul(**attrs, &block)
     end
 

--- a/lib/phlex_ui/pagination/ellipsis.rb
+++ b/lib/phlex_ui/pagination/ellipsis.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Pagination::Ellipsis < Base
-    def template(&block)
+    def view_template(&block)
       li do
         span(**attrs) do
           icon

--- a/lib/phlex_ui/pagination/item.rb
+++ b/lib/phlex_ui/pagination/item.rb
@@ -8,7 +8,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       li do
         a(href: @href, **attrs, &block)
       end

--- a/lib/phlex_ui/popover.rb
+++ b/lib/phlex_ui/popover.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/popover/content.rb
+++ b/lib/phlex_ui/popover/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Popover::Content < Base
-    def template(&block)
+    def view_template(&block)
       template_tag(data: {popover_target: "content"}) do
         div(**attrs, &block)
       end

--- a/lib/phlex_ui/popover/trigger.rb
+++ b/lib/phlex_ui/popover/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Popover::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/select.rb
+++ b/lib/phlex_ui/select.rb
@@ -10,7 +10,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/select/builder.rb
+++ b/lib/phlex_ui/select/builder.rb
@@ -17,7 +17,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template
+    def view_template
       render PhlexUI::Select.new(**attrs) do
         render PhlexUI::Select::Input.new(value: @object.send(@method), id: select_id, name: input_name, type: "hidden", **@input_attrs)
         render PhlexUI::Select::Trigger.new(**@trigger_attrs) do

--- a/lib/phlex_ui/select/content.rb
+++ b/lib/phlex_ui/select/content.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       template_tag(data: {popover_target: "content"}) do
         div(**attrs, &block)
       end

--- a/lib/phlex_ui/select/group.rb
+++ b/lib/phlex_ui/select/group.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Select::Group < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/select/input.rb
+++ b/lib/phlex_ui/select/input.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Select::Input < Base
-    def template
+    def view_template
       render PhlexUI::Input.new(**attrs)
     end
 

--- a/lib/phlex_ui/select/item.rb
+++ b/lib/phlex_ui/select/item.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs) do
         block&.call
         selected_icon

--- a/lib/phlex_ui/select/label.rb
+++ b/lib/phlex_ui/select/label.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Select::Label < Base
-    def template(&block)
+    def view_template(&block)
       h3(**attrs, &block)
     end
 

--- a/lib/phlex_ui/select/trigger.rb
+++ b/lib/phlex_ui/select/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Select::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       button(**attrs) do
         block&.call
         icon

--- a/lib/phlex_ui/select/value.rb
+++ b/lib/phlex_ui/select/value.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       span(**attrs) do
         block ? block.call : @placeholder
       end

--- a/lib/phlex_ui/sheet.rb
+++ b/lib/phlex_ui/sheet.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Sheet < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/sheet/content.rb
+++ b/lib/phlex_ui/sheet/content.rb
@@ -15,7 +15,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       template_tag(data: {sheet_target: "content"}) do
         div(data: {controller: "dismissable"}) do
           backdrop

--- a/lib/phlex_ui/sheet/description.rb
+++ b/lib/phlex_ui/sheet/description.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Sheet::Description < Base
-    def template(&block)
+    def view_template(&block)
       p(**attrs, &block)
     end
 

--- a/lib/phlex_ui/sheet/footer.rb
+++ b/lib/phlex_ui/sheet/footer.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Sheet::Footer < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/sheet/header.rb
+++ b/lib/phlex_ui/sheet/header.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Sheet::Header < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/sheet/middle.rb
+++ b/lib/phlex_ui/sheet/middle.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Sheet::Middle < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/sheet/title.rb
+++ b/lib/phlex_ui/sheet/title.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Sheet::Title < Base
-    def template(&block)
+    def view_template(&block)
       h3(**attrs, &block)
     end
 

--- a/lib/phlex_ui/sheet/trigger.rb
+++ b/lib/phlex_ui/sheet/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Sheet::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/shortcut_key.rb
+++ b/lib/phlex_ui/shortcut_key.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class ShortcutKey < Base
-    def template(&block)
+    def view_template(&block)
       kbd(**attrs, &block)
     end
 

--- a/lib/phlex_ui/table.rb
+++ b/lib/phlex_ui/table.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Table < Base
-    def template(&block)
+    def view_template(&block)
       div(class: "relative w-full overflow-auto") do
         table(**attrs, &block)
       end

--- a/lib/phlex_ui/table/body.rb
+++ b/lib/phlex_ui/table/body.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Table::Body < Base
-    def template(&block)
+    def view_template(&block)
       tbody(**attrs, &block)
     end
 

--- a/lib/phlex_ui/table/builder.rb
+++ b/lib/phlex_ui/table/builder.rb
@@ -13,7 +13,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       render PhlexUI::Table.new(**attrs) do
         header
         body

--- a/lib/phlex_ui/table/caption.rb
+++ b/lib/phlex_ui/table/caption.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Table::Caption < Base
-    def template(&block)
+    def view_template(&block)
       caption(**attrs, &block)
     end
 

--- a/lib/phlex_ui/table/cell.rb
+++ b/lib/phlex_ui/table/cell.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Table::Cell < Base
-    def template(&block)
+    def view_template(&block)
       td(**attrs, &block)
     end
 

--- a/lib/phlex_ui/table/footer.rb
+++ b/lib/phlex_ui/table/footer.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Table::Footer < Base
-    def template(&block)
+    def view_template(&block)
       tfoot(**attrs, &block)
     end
 

--- a/lib/phlex_ui/table/head.rb
+++ b/lib/phlex_ui/table/head.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Table::Head < Base
-    def template(&block)
+    def view_template(&block)
       th(**attrs, &block)
     end
 

--- a/lib/phlex_ui/table/header.rb
+++ b/lib/phlex_ui/table/header.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Table::Header < Base
-    def template(&block)
+    def view_template(&block)
       thead(**attrs, &block)
     end
 

--- a/lib/phlex_ui/table/row.rb
+++ b/lib/phlex_ui/table/row.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Table::Row < Base
-    def template(&block)
+    def view_template(&block)
       tr(**attrs, &block)
     end
 

--- a/lib/phlex_ui/tabs.rb
+++ b/lib/phlex_ui/tabs.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/tabs/content.rb
+++ b/lib/phlex_ui/tabs/content.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/tabs/list.rb
+++ b/lib/phlex_ui/tabs/list.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Tabs::List < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/tabs/trigger.rb
+++ b/lib/phlex_ui/tabs/trigger.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       button(**attrs, &block)
     end
 

--- a/lib/phlex_ui/theme_toggle.rb
+++ b/lib/phlex_ui/theme_toggle.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class ThemeToggle < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/tooltip.rb
+++ b/lib/phlex_ui/tooltip.rb
@@ -7,7 +7,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/tooltip/content.rb
+++ b/lib/phlex_ui/tooltip/content.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Tooltip::Content < Base
-    def template(&block)
+    def view_template(&block)
       template_tag(data: {popover_target: "content"}) do
         div(**attrs, &block)
       end

--- a/lib/phlex_ui/tooltip/trigger.rb
+++ b/lib/phlex_ui/tooltip/trigger.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Tooltip::Trigger < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/blockquote.rb
+++ b/lib/phlex_ui/typography/blockquote.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::Blockquote < Base
-    def template(&block)
+    def view_template(&block)
       blockquote(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/h1.rb
+++ b/lib/phlex_ui/typography/h1.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::H1 < Base
-    def template(&block)
+    def view_template(&block)
       h1(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/h2.rb
+++ b/lib/phlex_ui/typography/h2.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::H2 < Base
-    def template(&block)
+    def view_template(&block)
       h2(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/h3.rb
+++ b/lib/phlex_ui/typography/h3.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::H3 < Base
-    def template(&block)
+    def view_template(&block)
       h3(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/h4.rb
+++ b/lib/phlex_ui/typography/h4.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::H4 < Base
-    def template(&block)
+    def view_template(&block)
       h4(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/inline_code.rb
+++ b/lib/phlex_ui/typography/inline_code.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::InlineCode < Base
-    def template(&block)
+    def view_template(&block)
       code(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/inline_link.rb
+++ b/lib/phlex_ui/typography/inline_link.rb
@@ -7,7 +7,7 @@ module PhlexUI
       @href = href
     end
 
-    def template(&block)
+    def view_template(&block)
       a(href: @href, **attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/large.rb
+++ b/lib/phlex_ui/typography/large.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::Large < Base
-    def template(&block)
+    def view_template(&block)
       div(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/lead.rb
+++ b/lib/phlex_ui/typography/lead.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::Lead < Base
-    def template(&block)
+    def view_template(&block)
       p(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/list.rb
+++ b/lib/phlex_ui/typography/list.rb
@@ -8,7 +8,7 @@ module PhlexUI
       super(**attrs)
     end
 
-    def template(&block)
+    def view_template(&block)
       if @items.empty?
         list(**attrs, &block)
       else

--- a/lib/phlex_ui/typography/list_item.rb
+++ b/lib/phlex_ui/typography/list_item.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::ListItem < Base
-    def template(&block)
+    def view_template(&block)
       li(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/muted.rb
+++ b/lib/phlex_ui/typography/muted.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::Muted < Base
-    def template(&block)
+    def view_template(&block)
       p(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/p.rb
+++ b/lib/phlex_ui/typography/p.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::P < Base
-    def template(&block)
+    def view_template(&block)
       p(**attrs, &block)
     end
 

--- a/lib/phlex_ui/typography/small.rb
+++ b/lib/phlex_ui/typography/small.rb
@@ -2,7 +2,7 @@
 
 module PhlexUI
   class Typography::Small < Base
-    def template(&block)
+    def view_template(&block)
       small(**attrs, &block)
     end
 

--- a/phlex_ui.gemspec
+++ b/phlex_ui.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7"
 
-  s.add_dependency "phlex", "~> 1.7"
+  s.add_dependency "phlex", "~> 1.10"
   s.add_dependency "rouge", "~> 4.2.0"
   s.add_dependency "zeitwerk", "~> 2.6"
 


### PR DESCRIPTION
When opening the rails console, I would get the following message 148 times:

⚠️ [DEPRECATION] Defining the `template` method on a Phlex component will not be supported in Phlex 2.0. Please rename the method to `view_template` instead.

I renamed all of these with the following command:
```
rg -l "def template" | xargs -I@ sed -i '' 's/def template/def view_template/g' @
```