### PR TITLE
Fix clipboard popover rendering

### DIFF
--- a/lib/phlex_ui/clipboard.rb
+++ b/lib/phlex_ui/clipboard.rb
@@ -19,11 +19,11 @@ module PhlexUI
     private
 
     def success_popover
-      render Clipboard::Popover.new(type: :success) { @success }
+      ClipboardPopover(type: :success) { @success }
     end
 
     def error_popover
-      render Clipboard::Popover.new(type: :error) { @error }
+      ClipboardPopover(type: :error) { @error }
     end
 
     def default_attrs


### PR DESCRIPTION
This pull request fixes a bug in the `lib/phlex_ui/clipboard.rb` file.

The changes made in this commit address the issue by modifying the `success_popover` and `error_popover` methods. Instead of using `render Clipboard::Popover.new`, the code now uses the new syntax `ClipboardPopover` to render the popover.