### PR TITLE
Add Tailwind Merge to base component for automatic class merging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,9 @@ PATH
   specs:
     phlex_ui (0.1.10)
       activesupport (>= 6.0)
-      phlex (~> 1.11)
+      phlex (~> 1.10)
       rouge (~> 4.2.0)
+      tailwind_merge (= 0.12.0)
       zeitwerk (~> 2.6)
 
 GEM
@@ -23,6 +24,7 @@ GEM
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
+    lru_redux (1.1.0)
     minitest (5.24.0)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -66,6 +68,8 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.21.0)
     strscan (3.1.0)
+    tailwind_merge (0.12.0)
+      lru_redux (~> 1.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activesupport (>= 6.0)
       phlex (~> 1.10)
       rouge (~> 4.2.0)
-      tailwind_merge (= 0.12.0)
+      tailwind_merge (>= 0.12)
       zeitwerk (~> 2.6)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     phlex_ui (0.1.10)
-      phlex (~> 1.11)
+      phlex (~> 1.10)
       rouge (~> 4.2.0)
       tailwind_merge (>= 0.12)
       zeitwerk (~> 2.6)
@@ -60,8 +60,6 @@ GEM
     strscan (3.1.0)
     tailwind_merge (0.12.0)
       lru_redux (~> 1.1)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     zeitwerk (2.6.16)
 

--- a/lib/phlex_ui/attribute_merger.rb
+++ b/lib/phlex_ui/attribute_merger.rb
@@ -1,16 +1,19 @@
 module PhlexUI
   class AttributeMerger
     attr_reader :default_attrs, :user_attrs
-    OVERRIDE_KEY = "!".freeze
 
     def initialize(default_attrs, user_attrs)
       @default_attrs = flatten_hash(default_attrs)
       @user_attrs = flatten_hash(user_attrs)
     end
 
+    # @return [String]
+    # any key that ends with ! will override the default value
+    # ex: if default_attrs = { class: "text-right" }, user_attrs = { class!: "text-left" }
+    # the result will be { class: "text-left }
     def call
-      merged_attrs = merge_hashes(default_attrs, non_override_attrs)
-      mix(merged_attrs, override_attrs)
+      merged_attrs = merge_hashes(default_attrs, user_attrs)
+      mix(merged_attrs, user_attrs)
     end
 
     private
@@ -34,18 +37,6 @@ module PhlexUI
         result.transform_keys! do |key|
           key.end_with?("!") ? key.name.chop.to_sym : key
         end
-      end
-    end
-
-    def override_attrs
-      user_attrs.select do |key, value|
-        key.to_s.include?(OVERRIDE_KEY)
-      end
-    end
-
-    def non_override_attrs
-      user_attrs.reject do |key, value|
-        key.to_s.include?(OVERRIDE_KEY)
       end
     end
 

--- a/lib/phlex_ui/base.rb
+++ b/lib/phlex_ui/base.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require "tailwind_merge"
+
 module PhlexUI
   class Base < Phlex::HTML
     attr_reader :attrs
 
     def initialize(**user_attrs)
       @attrs = PhlexUI::AttributeMerger.new(default_attrs, user_attrs).call
+      @attrs[:class] = ::TailwindMerge::Merger.new.merge(@attrs[:class]) if @attrs[:class]
     end
 
     if defined?(Rails) && Rails.env.development?

--- a/phlex_ui.gemspec
+++ b/phlex_ui.gemspec
@@ -12,10 +12,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.2"
 
-  s.add_dependency "phlex", "~> 1.11"
+  s.add_dependency "phlex", "~> 1.10"
   s.add_dependency "rouge", "~> 4.2.0"
   s.add_dependency "zeitwerk", "~> 2.6"
   s.add_dependency "activesupport", ">= 6.0"
+  s.add_dependency "tailwind_merge", "0.12.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "standard"

--- a/phlex_ui.gemspec
+++ b/phlex_ui.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rouge", "~> 4.2.0"
   s.add_dependency "zeitwerk", "~> 2.6"
   s.add_dependency "activesupport", ">= 6.0"
-  s.add_dependency "tailwind_merge", "0.12.0"
+  s.add_dependency "tailwind_merge", ">= 0.12"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "standard"


### PR DESCRIPTION
## Overview
Integrated Tailwind Merge into the base component class, enabling automatic merging of Tailwind CSS classes for all components, both in their implementation and usage.

## Details
- Added to base component class, affecting all inheriting components
- Applies to internal component classes and classes added during component use
- Automatically merges and de-duplicates Tailwind classes

## Benefits
- Reduces CSS conflicts and redundancy
- Simplifies component development and usage
- Improves overall CSS efficiency

Related: [Tailwind Merge](https://github.com/gjtorikian/tailwind_merge)
