### PR TITLE
Set relaxed phlex version dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     phlex_ui (0.1.10)
-      phlex (~> 1.10)
+      phlex (>= 1.0, < 2.0)
       rouge (~> 4.2.0)
       tailwind_merge (>= 0.12)
       zeitwerk (~> 2.6)

--- a/phlex_ui.gemspec
+++ b/phlex_ui.gemspec
@@ -6,13 +6,12 @@ Gem::Specification.new do |s|
   s.authors = ["George Kettle"]
   s.email = "george.kettle@icloud.com"
   s.files = Dir["lib/**/*.rb", "tasks/**/*.rake"]
-  s.homepage =
-    "https://rubygems.org/gems/phlex_ui"
+  s.homepage = "https://rubygems.org/gems/phlex_ui"
   s.license = "MIT"
 
   s.required_ruby_version = ">= 3.2"
 
-  s.add_dependency "phlex", "~> 1.10"
+  s.add_dependency "phlex", ">= 1.0", "< 2.0"
   s.add_dependency "rouge", "~> 4.2.0"
   s.add_dependency "zeitwerk", "~> 2.6"
   s.add_dependency "tailwind_merge", ">= 0.12"


### PR DESCRIPTION
This configuration allows the use of any Phlex version between 1.0 and 2.0, making it more future-proof.