### PR TITLE
Fix attribute value duplication

### DIFF
--- a/lib/phlex_ui/attribute_merger.rb
+++ b/lib/phlex_ui/attribute_merger.rb
@@ -1,6 +1,7 @@
 module PhlexUI
   class AttributeMerger
     attr_reader :default_attrs, :user_attrs
+    OVERRIDE_KEY = "!".freeze
 
     def initialize(default_attrs, user_attrs)
       @default_attrs = flatten_hash(default_attrs)
@@ -12,8 +13,8 @@ module PhlexUI
     # ex: if default_attrs = { class: "text-right" }, user_attrs = { class!: "text-left" }
     # the result will be { class: "text-left }
     def call
-      merged_attrs = merge_hashes(default_attrs, user_attrs)
-      mix(merged_attrs, user_attrs)
+      merged_attrs = merge_hashes(default_attrs, non_override_attrs)
+      mix(merged_attrs, override_attrs)
     end
 
     private
@@ -37,6 +38,18 @@ module PhlexUI
         result.transform_keys! do |key|
           key.end_with?("!") ? key.name.chop.to_sym : key
         end
+      end
+    end
+
+    def override_attrs
+      user_attrs.select do |key, value|
+        key.to_s[-1] == OVERRIDE_KEY
+      end
+    end
+
+    def non_override_attrs
+      user_attrs.reject do |key, value|
+        key.to_s[-1] == OVERRIDE_KEY
       end
     end
 

--- a/test/phlex_ui/input_test.rb
+++ b/test/phlex_ui/input_test.rb
@@ -10,7 +10,7 @@ class PhlexUI::InputTest < Minitest::Test
       PhlexUI.Input(type: "email", placeholder: "Email")
     end
 
-    assert_match(/Email/, output)
+    assert_match(/placeholder="Email"/, output)
   end
 
   def test_no_destructive_classes_when_error_absent


### PR DESCRIPTION
This PR fixes the attribute value duplication introduced by the latest Tailwind Merger PR.

For now, I have restored the functionality to fully override attributes using "!" at the end and also updated the test to catch this issue in the future.

![CleanShot 2024-08-01 at 17 35 26@2x](https://github.com/user-attachments/assets/e6083b42-cef1-4ff7-b970-e5b0c78884ee)

