### PR TITLE
Add missing Input component classes

### DIFF
--- a/lib/rbui/input/input.rb
+++ b/lib/rbui/input/input.rb
@@ -19,7 +19,7 @@ module RBUI
           rbui__form_field_target: "input",
           action: "input->rbui--form-field#onInput invalid->rbui--form-field#onInvalid"
         },
-        class: "flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50"
+        class: "flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 border-border focus-visible:ring-ring placeholder:text-muted-foreground"
       }
     end
   end


### PR DESCRIPTION
I found that there are missing classes from the `Input` component when I migrated from `main` branch to `v1` branch. The classes are:

- `border-border`
- `focus-visible:ring-ring`
- `placeholder:text-muted-foreground`

Without them the `Input` component has a blue ring, instead of using the theme var.