### PR TITLE
cache TailwindMerge instance

### DIFF
--- a/lib/phlex_ui/base.rb
+++ b/lib/phlex_ui/base.rb
@@ -5,7 +5,7 @@ require "tailwind_merge"
 module PhlexUI
   class Base < Phlex::HTML
     TAILWIND_MERGER = TailwindMerge::Merger.new.freeze
-    
+
     attr_reader :attrs
 
     def initialize(**user_attrs)

--- a/lib/phlex_ui/base.rb
+++ b/lib/phlex_ui/base.rb
@@ -4,11 +4,13 @@ require "tailwind_merge"
 
 module PhlexUI
   class Base < Phlex::HTML
+    TAILWIND_MERGER = TailwindMerge::Merger.new.freeze
+    
     attr_reader :attrs
 
     def initialize(**user_attrs)
       @attrs = mix(default_attrs, user_attrs)
-      @attrs[:class] = ::TailwindMerge::Merger.new.merge(@attrs[:class]) if @attrs[:class]
+      @attrs[:class] = TAILWIND_MERGER.merge(@attrs[:class]) if @attrs[:class]
     end
 
     if defined?(Rails) && Rails.env.development?


### PR DESCRIPTION
This is a resubmission of https://github.com/PhlexUI/phlex_ui/pull/94

----

TailwindMerge operates a cache and undertakes a lot of operations that require that an instance be reused rather than constantly instantiating one.

I added a simple benchmark

```console
################ Simple ################

* Single run:
                           user     system      total        real
Cached:                0.000234   0.000006   0.000240 (  0.000237)
Uncached:              0.004120   0.000448   0.004568 (  0.004769)
== Cached is 20.12x faster than Uncached.

* 1000 runs:
                           user     system      total        real
Cached:                0.001120   0.000013   0.001133 (  0.001332)
Uncached:              2.199289   0.036016   2.235305 (  2.511064)
== Cached is 1885.18x faster than Uncached.

* Iterations per second (5 second run):
Cached: 877208
Uncached: 452
== Cached performs 1940.73x more iterations per second than Uncached.
-------------------------------------------------------------------------------------
```

<details>
<summary>Benchmark Code</summary>

```ruby
require "benchmark"
require "tailwind_merge"

class CachedMerger
  MERGER = TailwindMerge::Merger.new.freeze

  def call(classes)
    MERGER.merge(classes)
  end
end

class UncachedMerger
  def call(classes)
    TailwindMerge::Merger.new.merge(classes)
  end
end

def run_benchmark(name, classes)
  puts "\n################ #{name} ################\n"

  puts "\n* Single run:"
  single_results = Benchmark.bm(20) do |x|
    x.report("Cached:") { CachedMerger.new.call(classes) }
    x.report("Uncached:") { UncachedMerger.new.call(classes) }
  end
  compare_results(single_results, "Single run")

  puts "\n* 1000 runs:"
  bulk_results = Benchmark.bm(20) do |x|
    x.report("Cached:") { 1000.times { CachedMerger.new.call(classes) } }
    x.report("Uncached:") { 1000.times { UncachedMerger.new.call(classes) } }
  end
  compare_results(bulk_results, "1000 runs")

  # Simple IPS-like benchmark
  duration = 5 # Run for 5 seconds
  puts "\n* Iterations per second (5 second run):"
  ips_results = [
    ["Cached", -> { CachedMerger.new.call(classes) }],
    ["Uncached", -> { UncachedMerger.new.call(classes) }]
  ].map do |name, proc|
    iterations = 0
    start_time = Time.now
    while Time.now - start_time < duration
      proc.call
      iterations += 1
    end
    ips = iterations / duration
    puts "#{name}: #{ips.round(2)}"
    [name, ips]
  end
  compare_ips(ips_results)

  puts "-------------------------------------------------------------------------------------"
end

def compare_results(results, label)
  our_time = results[0].real
  phlex_time = results[1].real
  faster, slower = (our_time < phlex_time) ? ["Cached", "Uncached"] : ["Uncached", "Cached"]
  multiplier = [our_time, phlex_time].max / [our_time, phlex_time].min

  puts "== #{faster} is #{multiplier.round(2)}x faster than #{slower}."
end

def compare_ips(results)
  our_ips, phlex_ips = results.map { |_, ips| ips.to_f }
  faster, slower = (our_ips > phlex_ips) ? ["Cached", "Uncached"] : ["Uncached", "Cached"]
  multiplier = [our_ips, phlex_ips].max / [our_ips, phlex_ips].min

  puts "== #{faster} performs #{multiplier.round(2)}x more iterations per second than #{slower}."
end

# Run benchmarks
run_benchmark(
  "Simple",
  "inline-block h-12 w-12 rounded-full ring-2 ring-white block font-bold px-3 py-2 text-slate-700 rounded-lg hover:bg-slate-100 hover:text-slate-900"
)

```
</details>