### PR TITLE
Prevent body scroll while alert dialog is open

### DIFF
--- a/lib/rbui/alert_dialog/alert_dialog_controller.js
+++ b/lib/rbui/alert_dialog/alert_dialog_controller.js
@@ -18,12 +18,14 @@ export default class extends Controller {
 
   open() {
     document.body.insertAdjacentHTML("beforeend", this.contentTarget.innerHTML);
+    // prevent scroll on body
+    document.body.classList.add("overflow-hidden");
   }
 
   dismiss(e) {
     // allow scroll on body
-    document.body.classList.remove('overflow-hidden')
+    document.body.classList.remove("overflow-hidden");
     // remove the element
-    this.element.remove()
+    this.element.remove();
   }
 }


### PR DESCRIPTION
Applying "overflow-hidden" class to the document's body to prevent scroll while alert dialog is open.

This is already done in the dialog controller, but was not in the alert dialog controller.