### PR TITLE
FIX Select `fixed`

### DIFF
--- a/lib/rbui/select/select_content.rb
+++ b/lib/rbui/select/select_content.rb
@@ -10,7 +10,7 @@ module RBUI
     def view_template(&block)
       div(**attrs) do
         div(
-          class: "fixed max-h-96 min-w-max overflow-auto rounded-md border bg-background p-1 text-foreground shadow-md animate-out group-data-[rbui--select-open-value=true]/select:animate-in fade-out-0 group-data-[rbui--select-open-value=true]/select:fade-in-0 zoom-out-95 group-data-[rbui--select-open-value=true]/select:zoom-in-95 slide-in-from-top-2", &block
+          class: "max-h-96 min-w-max overflow-auto rounded-md border bg-background p-1 text-foreground shadow-md animate-out group-data-[rbui--select-open-value=true]/select:animate-in fade-out-0 group-data-[rbui--select-open-value=true]/select:fade-in-0 zoom-out-95 group-data-[rbui--select-open-value=true]/select:zoom-in-95 slide-in-from-top-2", &block
         )
       end
     end


### PR DESCRIPTION
Recently I've submitted a PR and I broke the default behavior on Select component

### BEFORE
![image](https://github.com/user-attachments/assets/7180cb61-cdc1-43b5-8c21-383ce3a225d0)

### AFTER
![image](https://github.com/user-attachments/assets/1529895d-297f-426c-9042-49c82af9737b)